### PR TITLE
add alsa-firmware to kickstarts

### DIFF
--- a/ISO-ready-flattened-kickstarts/39/flat-nobara-live-gnome-39.ks
+++ b/ISO-ready-flattened-kickstarts/39/flat-nobara-live-gnome-39.ks
@@ -439,6 +439,7 @@ firefox
 apparmor-utils
 apparmor-parser
 aajohan-comfortaa-fonts
+alsa-firmware
 anaconda
 anaconda-install-env-deps
 anaconda-live

--- a/ISO-ready-flattened-kickstarts/39/flat-nobara-live-kde-39.ks
+++ b/ISO-ready-flattened-kickstarts/39/flat-nobara-live-kde-39.ks
@@ -22,7 +22,8 @@ repo --name="nobara-appstream" --baseurl=https://nobara-appstream.nobaraproject.
 repo --name="nobara-rocm-official" --baseurl=https://repo.radeon.com/rocm/rhel9/5.6.1/main/ --cost=50
 repo --name="fedora" --baseurl=https://nobara-fedora.nobaraproject.org/$releasever/
 repo --name="fedora-updates" --baseurl=https://nobara-fedora-updates.nobaraproject.org/$releasever/
-
+repo --name="nobara-kde6" --baseurl=https://kde6.nobaraproject.org/ --cost=49
+repo --name="nobara-kde6-overrides" --baseurl=https://kde6-overrides.nobaraproject.org/ --cost=49
 # System timezone
 timezone US/Eastern
 # SELinux configuration

--- a/ISO-ready-flattened-kickstarts/39/flat-nobara-live-kde-39.ks
+++ b/ISO-ready-flattened-kickstarts/39/flat-nobara-live-kde-39.ks
@@ -22,8 +22,7 @@ repo --name="nobara-appstream" --baseurl=https://nobara-appstream.nobaraproject.
 repo --name="nobara-rocm-official" --baseurl=https://repo.radeon.com/rocm/rhel9/5.6.1/main/ --cost=50
 repo --name="fedora" --baseurl=https://nobara-fedora.nobaraproject.org/$releasever/
 repo --name="fedora-updates" --baseurl=https://nobara-fedora-updates.nobaraproject.org/$releasever/
-repo --name="nobara-kde6" --baseurl=https://kde6.nobaraproject.org/ --cost=49
-repo --name="nobara-kde6-overrides" --baseurl=https://kde6-overrides.nobaraproject.org/ --cost=49
+
 # System timezone
 timezone US/Eastern
 # SELinux configuration

--- a/ISO-ready-flattened-kickstarts/39/flat-nobara-live-kde-39.ks
+++ b/ISO-ready-flattened-kickstarts/39/flat-nobara-live-kde-39.ks
@@ -458,6 +458,7 @@ firefox
 apparmor-utils
 apparmor-parser
 aajohan-comfortaa-fonts
+alsa-firmware
 anaconda
 anaconda-install-env-deps
 anaconda-live

--- a/ISO-ready-flattened-kickstarts/39/flat-nobara-live-official-39.ks
+++ b/ISO-ready-flattened-kickstarts/39/flat-nobara-live-official-39.ks
@@ -459,6 +459,7 @@ firefox
 apparmor-utils
 apparmor-parser
 aajohan-comfortaa-fonts
+alsa-firmware
 anaconda
 anaconda-install-env-deps
 anaconda-live

--- a/ISO-ready-flattened-kickstarts/39/flat-nobara-live-official-39.ks
+++ b/ISO-ready-flattened-kickstarts/39/flat-nobara-live-official-39.ks
@@ -22,6 +22,8 @@ repo --name="nobara-appstream" --baseurl=https://nobara-appstream.nobaraproject.
 repo --name="nobara-rocm-official" --baseurl=https://repo.radeon.com/rocm/rhel9/5.6.1/main/ --cost=50
 repo --name="fedora" --baseurl=https://nobara-fedora.nobaraproject.org/$releasever/
 repo --name="fedora-updates" --baseurl=https://nobara-fedora-updates.nobaraproject.org/$releasever/
+repo --name="nobara-kde6" --baseurl=https://kde6.nobaraproject.org/ --cost=49
+repo --name="nobara-kde6-overrides" --baseurl=https://kde6-overrides.nobaraproject.org/ --cost=49
 
 # System timezone
 timezone US/Eastern

--- a/ISO-ready-flattened-kickstarts/39/flat-nobara-live-official-39.ks
+++ b/ISO-ready-flattened-kickstarts/39/flat-nobara-live-official-39.ks
@@ -22,8 +22,6 @@ repo --name="nobara-appstream" --baseurl=https://nobara-appstream.nobaraproject.
 repo --name="nobara-rocm-official" --baseurl=https://repo.radeon.com/rocm/rhel9/5.6.1/main/ --cost=50
 repo --name="fedora" --baseurl=https://nobara-fedora.nobaraproject.org/$releasever/
 repo --name="fedora-updates" --baseurl=https://nobara-fedora-updates.nobaraproject.org/$releasever/
-repo --name="nobara-kde6" --baseurl=https://kde6.nobaraproject.org/ --cost=49
-repo --name="nobara-kde6-overrides" --baseurl=https://kde6-overrides.nobaraproject.org/ --cost=49
 
 # System timezone
 timezone US/Eastern

--- a/ISO-ready-flattened-kickstarts/39/flat-nobara-live-steamdeck-39.ks
+++ b/ISO-ready-flattened-kickstarts/39/flat-nobara-live-steamdeck-39.ks
@@ -459,6 +459,7 @@ firefox
 apparmor-utils
 apparmor-parser
 aajohan-comfortaa-fonts
+alsa-firmware
 anaconda
 anaconda-install-env-deps
 anaconda-live

--- a/ISO-ready-flattened-kickstarts/39/flat-nobara-live-steamdeck-39.ks
+++ b/ISO-ready-flattened-kickstarts/39/flat-nobara-live-steamdeck-39.ks
@@ -22,6 +22,8 @@ repo --name="nobara-appstream" --baseurl=https://nobara-appstream.nobaraproject.
 repo --name="nobara-rocm-official" --baseurl=https://repo.radeon.com/rocm/rhel9/5.6.1/main/ --cost=50
 repo --name="fedora" --baseurl=https://nobara-fedora.nobaraproject.org/$releasever/
 repo --name="fedora-updates" --baseurl=https://nobara-fedora-updates.nobaraproject.org/$releasever/
+repo --name="nobara-kde6" --baseurl=https://kde6.nobaraproject.org/ --cost=49
+repo --name="nobara-kde6-overrides" --baseurl=https://kde6-overrides.nobaraproject.org/ --cost=49
 
 # System timezone
 timezone US/Eastern

--- a/ISO-ready-flattened-kickstarts/39/flat-nobara-live-steamdeck-39.ks
+++ b/ISO-ready-flattened-kickstarts/39/flat-nobara-live-steamdeck-39.ks
@@ -22,8 +22,6 @@ repo --name="nobara-appstream" --baseurl=https://nobara-appstream.nobaraproject.
 repo --name="nobara-rocm-official" --baseurl=https://repo.radeon.com/rocm/rhel9/5.6.1/main/ --cost=50
 repo --name="fedora" --baseurl=https://nobara-fedora.nobaraproject.org/$releasever/
 repo --name="fedora-updates" --baseurl=https://nobara-fedora-updates.nobaraproject.org/$releasever/
-repo --name="nobara-kde6" --baseurl=https://kde6.nobaraproject.org/ --cost=49
-repo --name="nobara-kde6-overrides" --baseurl=https://kde6-overrides.nobaraproject.org/ --cost=49
 
 # System timezone
 timezone US/Eastern

--- a/ISO-ready-flattened-kickstarts/39/nv-flat-nobara-live-gnome-39.ks
+++ b/ISO-ready-flattened-kickstarts/39/nv-flat-nobara-live-gnome-39.ks
@@ -447,6 +447,7 @@ firefox
 apparmor-utils
 apparmor-parser
 aajohan-comfortaa-fonts
+alsa-firmware
 anaconda
 anaconda-install-env-deps
 anaconda-live

--- a/ISO-ready-flattened-kickstarts/39/nv-flat-nobara-live-kde-39.ks
+++ b/ISO-ready-flattened-kickstarts/39/nv-flat-nobara-live-kde-39.ks
@@ -464,6 +464,7 @@ firefox
 apparmor-utils
 apparmor-parser
 aajohan-comfortaa-fonts
+alsa-firmware
 anaconda
 anaconda-install-env-deps
 anaconda-live

--- a/ISO-ready-flattened-kickstarts/39/nv-flat-nobara-live-kde-39.ks
+++ b/ISO-ready-flattened-kickstarts/39/nv-flat-nobara-live-kde-39.ks
@@ -22,6 +22,8 @@ repo --name="nobara-appstream" --baseurl=https://nobara-appstream.nobaraproject.
 repo --name="nobara-rocm-official" --baseurl=https://repo.radeon.com/rocm/rhel9/5.6.1/main/ --cost=50
 repo --name="fedora" --baseurl=https://nobara-fedora.nobaraproject.org/$releasever/
 repo --name="fedora-updates" --baseurl=https://nobara-fedora-updates.nobaraproject.org/$releasever/
+repo --name="nobara-kde6" --baseurl=https://kde6.nobaraproject.org/ --cost=49
+repo --name="nobara-kde6-overrides" --baseurl=https://kde6-overrides.nobaraproject.org/ --cost=49
 
 # System timezone
 timezone US/Eastern

--- a/ISO-ready-flattened-kickstarts/39/nv-flat-nobara-live-kde-39.ks
+++ b/ISO-ready-flattened-kickstarts/39/nv-flat-nobara-live-kde-39.ks
@@ -22,8 +22,6 @@ repo --name="nobara-appstream" --baseurl=https://nobara-appstream.nobaraproject.
 repo --name="nobara-rocm-official" --baseurl=https://repo.radeon.com/rocm/rhel9/5.6.1/main/ --cost=50
 repo --name="fedora" --baseurl=https://nobara-fedora.nobaraproject.org/$releasever/
 repo --name="fedora-updates" --baseurl=https://nobara-fedora-updates.nobaraproject.org/$releasever/
-repo --name="nobara-kde6" --baseurl=https://kde6.nobaraproject.org/ --cost=49
-repo --name="nobara-kde6-overrides" --baseurl=https://kde6-overrides.nobaraproject.org/ --cost=49
 
 # System timezone
 timezone US/Eastern

--- a/ISO-ready-flattened-kickstarts/39/nv-flat-nobara-live-official-39.ks
+++ b/ISO-ready-flattened-kickstarts/39/nv-flat-nobara-live-official-39.ks
@@ -464,6 +464,7 @@ firefox
 apparmor-utils
 apparmor-parser
 aajohan-comfortaa-fonts
+alsa-firmware
 anaconda
 anaconda-install-env-deps
 anaconda-live

--- a/ISO-ready-flattened-kickstarts/39/nv-flat-nobara-live-official-39.ks
+++ b/ISO-ready-flattened-kickstarts/39/nv-flat-nobara-live-official-39.ks
@@ -22,6 +22,8 @@ repo --name="nobara-appstream" --baseurl=https://nobara-appstream.nobaraproject.
 repo --name="nobara-rocm-official" --baseurl=https://repo.radeon.com/rocm/rhel9/5.6.1/main/ --cost=50
 repo --name="fedora" --baseurl=https://nobara-fedora.nobaraproject.org/$releasever/
 repo --name="fedora-updates" --baseurl=https://nobara-fedora-updates.nobaraproject.org/$releasever/
+repo --name="nobara-kde6" --baseurl=https://kde6.nobaraproject.org/ --cost=49
+repo --name="nobara-kde6-overrides" --baseurl=https://kde6-overrides.nobaraproject.org/ --cost=49
 
 # System timezone
 timezone US/Eastern

--- a/ISO-ready-flattened-kickstarts/39/nv-flat-nobara-live-official-39.ks
+++ b/ISO-ready-flattened-kickstarts/39/nv-flat-nobara-live-official-39.ks
@@ -22,8 +22,6 @@ repo --name="nobara-appstream" --baseurl=https://nobara-appstream.nobaraproject.
 repo --name="nobara-rocm-official" --baseurl=https://repo.radeon.com/rocm/rhel9/5.6.1/main/ --cost=50
 repo --name="fedora" --baseurl=https://nobara-fedora.nobaraproject.org/$releasever/
 repo --name="fedora-updates" --baseurl=https://nobara-fedora-updates.nobaraproject.org/$releasever/
-repo --name="nobara-kde6" --baseurl=https://kde6.nobaraproject.org/ --cost=49
-repo --name="nobara-kde6-overrides" --baseurl=https://kde6-overrides.nobaraproject.org/ --cost=49
 
 # System timezone
 timezone US/Eastern

--- a/nobara-39-x86_64.cfg
+++ b/nobara-39-x86_64.cfg
@@ -98,31 +98,12 @@ priority=50
 
 [nobara-rocm-official]
 name=nobara-rocm-official
-baseurl=https://repo.radeon.com/rocm/rhel9/6.0.2/main/
+baseurl=https://repo.radeon.com/rocm/rhel9/5.6.1/main/
 enabled=1
 gpgcheck=1
 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
 priority=50
 
 
-[nobara-kde6]
-name=nobara-kde6
-mirrorlist=https://mirrors.nobaraproject.org/kde6
-gpgcheck=1
-gpgkey=https://copr-dist-git.fedorainfracloud.org/cgit/gloriouseggroll/nobara-39/nobara-repos.git/plain/RPM-GPG-KEY-nobara-kde6-pubkey?h=f39&id=dfb90400d15c4f599228e7420e396ddbf68077df
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1
-priority=49
-
-[nobara-kde6-overrides]
-name=nobara-kde6-overrides
-mirrorlist=https://mirrors.nobaraproject.org/kde6-overrides
-gpgcheck=1
-gpgkey=https://copr-dist-git.fedorainfracloud.org/cgit/gloriouseggroll/nobara-39/nobara-repos.git/plain/RPM-GPG-KEY-nobara-kde6-overrides-pubkey?h=f39&id=dfb90400d15c4f599228e7420e396ddbf68077df
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1
-priority=49
 
 """

--- a/nobara-39-x86_64.cfg
+++ b/nobara-39-x86_64.cfg
@@ -98,12 +98,31 @@ priority=50
 
 [nobara-rocm-official]
 name=nobara-rocm-official
-baseurl=https://repo.radeon.com/rocm/rhel9/5.6.1/main/
+baseurl=https://repo.radeon.com/rocm/rhel9/6.0.2/main/
 enabled=1
 gpgcheck=1
 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
 priority=50
 
 
+[nobara-kde6]
+name=nobara-kde6
+mirrorlist=https://mirrors.nobaraproject.org/kde6
+gpgcheck=1
+gpgkey=https://copr-dist-git.fedorainfracloud.org/cgit/gloriouseggroll/nobara-39/nobara-repos.git/plain/RPM-GPG-KEY-nobara-kde6-pubkey?h=f39&id=dfb90400d15c4f599228e7420e396ddbf68077df
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1
+priority=49
+
+[nobara-kde6-overrides]
+name=nobara-kde6-overrides
+mirrorlist=https://mirrors.nobaraproject.org/kde6-overrides
+gpgcheck=1
+gpgkey=https://copr-dist-git.fedorainfracloud.org/cgit/gloriouseggroll/nobara-39/nobara-repos.git/plain/RPM-GPG-KEY-nobara-kde6-overrides-pubkey?h=f39&id=dfb90400d15c4f599228e7420e396ddbf68077df
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1
+priority=49
 
 """


### PR DESCRIPTION
related to https://github.com/Nobara-Project/nobara-core-packages/pull/5

let's add `alsa-firmware` to the kickstarts. bazzite has used it for the past 6 months without issue:
https://discord.com/channels/110175050006577152/1042846022596042792/1224638987340353546